### PR TITLE
feat: 로그인할 때 닉네임이 3글자 초과되면 UI무너지는 이슈

### DIFF
--- a/src/views/login/login.html
+++ b/src/views/login/login.html
@@ -55,6 +55,7 @@
             type="text"
             placeholder="닉네임을 입력해 주세요"
             id="nameInput"
+            maxlength="7"
           />
         </div>
         <div>

--- a/src/views/login/login.js
+++ b/src/views/login/login.js
@@ -22,12 +22,28 @@ const nameInput = document.querySelector("#nameInput");
 const quoteInput = document.querySelector("#quoteInput");
 
 loginSuccess.addEventListener("click", (e) => {
-  const informationData = {
-    nickName: nameInput.value,
-    quote: quoteInput.value,
-  };
-  localStorage.setItem("myInfo", JSON.stringify(informationData));
-  location.href = "../landing/landing.html";
+  const inputValue = nameInput.value;
+  const inputLength = inputValue.replace(
+    /[\0-\x7f]|([0-\u07ff]|(.))/g,
+    "$&$1$2"
+  ).length;
+  console.log(inputLength);
+  if (inputLength > 10 || inputLength === 0) {
+    e.preventDefault();
+    notAvailableSection.style.display = "block";
+    notAvailableH2.innerText =
+      "이름은 국문 3글자,\n영문 7글자 이내로 설정해주세요";
+    notAvailableButton.addEventListener("click", () => {
+      window.location.href = "../login/login.html";
+    });
+  } else {
+    const informationData = {
+      nickName: inputValue,
+      quote: quoteInput.value,
+    };
+    localStorage.setItem("myInfo", JSON.stringify(informationData));
+    location.href = "../landing/landing.html";
+  }
 });
 
 if (localStorage.getItem("myInfo")) {


### PR DESCRIPTION
로그인할 때 한글 3글자 영어 8글자가 되면 ui가 무너지는 이슈

로그인시 글자의 바이트 수를 체크
한글 3글자 => 9, 영어 8글자 => 8 이라서 input의 max-length를 7로 설정하고, js에서 바이트가 9보다 클 경우 알림창을 띄움

Resolves: #67